### PR TITLE
Fix `Threads` lib error

### DIFF
--- a/FindSDL2.cmake
+++ b/FindSDL2.cmake
@@ -237,7 +237,7 @@ endif()
 # But for non-OSX systems, I will use the CMake Threads package.
 if(NOT APPLE)
   find_package(Threads QUIET)
-  if(NOT CMAKE_THREAD_LIBS_INIT)
+  if(NOT Threads_FOUND)
     set(SDL2_THREADS_NOT_FOUND "Could NOT find Threads (Threads is required by SDL2).")
     if(SDL2_FIND_REQUIRED)
       message(FATAL_ERROR ${SDL2_THREADS_NOT_FOUND})


### PR DESCRIPTION
Sometimes `CMAKE_THREAD_LIBS_INIT` won't be defined even though
the library is found.